### PR TITLE
Updates README to explain why we are using this fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,7 @@
-# Go Cryptography
+# cert-manager fork of golang/x/crypto
 
-[![Go Reference](https://pkg.go.dev/badge/golang.org/x/crypto.svg)](https://pkg.go.dev/golang.org/x/crypto)
+This is a fork of `golang/x/crypto` with added support for fetching [ACME alternative certificate chains](https://tools.ietf.org/html/rfc8555#section-7.4.2) by Maartje Eyskens.
 
-This repository holds supplementary Go cryptography libraries.
+The support for fetching alternative certificate chains allows us to give users an option to [specify a preferred chain](https://cert-manager.io/docs/release-notes/release-notes-1.0/#preferred-chain) to be fetched i.e from Let's Encrypt.
 
-## Download/Install
-
-The easiest way to install is to run `go get -u golang.org/x/crypto/...`. You
-can also manually git clone the repository to `$GOPATH/src/golang.org/x/crypto`.
-
-## Report Issues / Send Patches
-
-This repository uses Gerrit for code changes. To learn how to submit changes to
-this repository, see https://golang.org/doc/contribute.html.
-
-The main issue tracker for the crypto repository is located at
-https://github.com/golang/go/issues. Prefix your issue with "x/crypto:" in the
-subject line, so it is easy to find.
-
-Note that contributions to the cryptography package receive additional scrutiny
-due to their sensitive nature. Patches may take longer than normal to receive
-feedback.
+There is an active CL ([#2777294](https://go-review.googlesource.com/c/crypto/+/277294/)) in upstream `golang/x/crypto` that adds support for fetching alternative certificate chains. Once that gets merged, we will be able to start using upstream again.


### PR DESCRIPTION
This is a README update that would explain why we are using this fork.

This should be merged together with https://github.com/jetstack/cert-manager/pull/3850 which actually starts using _this_ fork- currently we still use the one from Maartje's account.

Signed-off-by: irbekrm <irbekrm@gmail.com>