### PR TITLE
WIP: acme: adds support for profiles draft

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -186,10 +186,11 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Nonce     string `json:"newNonce"`
 		KeyChange string `json:"keyChange"`
 		Meta      struct {
-			Terms        string   `json:"termsOfService"`
-			Website      string   `json:"website"`
-			CAA          []string `json:"caaIdentities"`
-			ExternalAcct bool     `json:"externalAccountRequired"`
+			Terms        string            `json:"termsOfService"`
+			Website      string            `json:"website"`
+			CAA          []string          `json:"caaIdentities"`
+			ExternalAcct bool              `json:"externalAccountRequired"`
+			Profiles     map[string]string `json:"profiles"`
 		}
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
@@ -209,6 +210,7 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Website:                 v.Meta.Website,
 		CAA:                     v.Meta.CAA,
 		ExternalAccountRequired: v.Meta.ExternalAcct,
+		Profiles:                v.Meta.Profiles,
 	}
 	return *c.dir, nil
 }


### PR DESCRIPTION
Let's Encrypt is already supporting Profiles in requests made to the new-order endoint and returning them in the meta field of the directory. This parses those and adds a new OrderOption to enable specifying this when constructing the new order request via AuthorizeOrder.

When Profiles are not supported, this returns an error early. When the specified profile name is not in the list of specified profiles, an error is returned early.

Fixes golang/go#73101

Change-Id: I6a7cdba126d8a0bfb04c6ca6cd06fad9871239d5 (cherry picked from commit c622daa7bb7676bd5480b7f49679e5e4c2adb4fb)